### PR TITLE
fix(#14): New sleepMs() implementation for hardware::Simulator

### DIFF
--- a/software/include/hardware/simulator/Simulator.h
+++ b/software/include/hardware/simulator/Simulator.h
@@ -36,7 +36,7 @@ namespace hardware {
  * hardware target.
  */
 class Simulator : public IHardware {
-public:
+ public:
   Simulator(unsigned long initialMillis = 0);
   virtual ~Simulator();
   void sleepMs(uint16_t ms) override;
@@ -63,13 +63,11 @@ public:
   void TriggerPrimaryAction();
   void TriggerSecondaryAction();
 
-private:
-  tools::Timer _millisClock;
+ private:
   tools::Timer _tickClock;
-  unsigned long _millis;
+  uint64_t _millis;
   long _primaryActionExecutionCount;
   long _secondaryActionExecutionCount;
   std::mutex _tickMutex;
-  std::mutex _millisMutex;
 };
-} // namespace hardware
+}  // namespace hardware

--- a/software/include/tools/Timer.h
+++ b/software/include/tools/Timer.h
@@ -20,6 +20,8 @@
 
 #include <mutex>
 #include <thread>
+#include <time.h>
+
 
 namespace tools {
 /*!
@@ -45,7 +47,7 @@ public:
   }
 
   template <typename Function>
-  void SetInterval(Function function, int interval) {
+  void SetInterval(Function function, int interval) { 
     this->clear = false;
     std::thread t([=]() {
       while (true) {

--- a/software/tests/SimulatorTest.cpp
+++ b/software/tests/SimulatorTest.cpp
@@ -21,6 +21,7 @@
 #include <chrono>
 #include <iostream>
 #include <numeric>
+#include <mutex>
 
 #ifndef AVR
 #define UNITY_OUTPUT_COLOR
@@ -35,7 +36,7 @@ void Expect_simulator_to_be_clocked();
 void Expect_simulator_to_have_a_primary_action();
 void Expect_simulator_to_have_a_secondary_action();
 void Expect_simulator_to_be_able_to_sleep_for_some_ms();
-void Expect_simulator_to_wait_10ms_during_waitForEvent();
+void Expect_simulator_to_wait_30ms_during_waitForEvent();
 void Expect_simulator_millis_to_overflow_after_max_unsigned_long();
 void Expect_simulator_millis_to_not_overflow_in_normal_condition();
 
@@ -45,7 +46,7 @@ int main(int, char **) {
   RUN_TEST(Expect_simulator_to_be_clocked);
   RUN_TEST(Expect_simulator_to_have_a_primary_action);
   RUN_TEST(Expect_simulator_to_have_a_secondary_action);
-  RUN_TEST(Expect_simulator_to_wait_10ms_during_waitForEvent);
+  RUN_TEST(Expect_simulator_to_wait_30ms_during_waitForEvent);
   RUN_TEST(Expect_simulator_millis_to_overflow_after_max_unsigned_long);
   RUN_TEST(Expect_simulator_millis_to_not_overflow_in_normal_condition);
   return UNITY_END();
@@ -55,7 +56,8 @@ void Expect_simulator_millis_to_not_overflow_in_normal_condition() {
   hardware::Simulator hw;
   hw.sleepMs(100);
   unsigned long iMustBeAround100 = hw.Millis();
-  TEST_ASSERT_INT_WITHIN(10, 100, iMustBeAround100);
+  hw.Stop();
+  TEST_ASSERT_INT_WITHIN(20, 100, iMustBeAround100);
 }
 
 void Expect_simulator_millis_to_overflow_after_max_unsigned_long() {
@@ -63,6 +65,7 @@ void Expect_simulator_millis_to_overflow_after_max_unsigned_long() {
   hardware::Simulator hw(nearOverflow);
   hw.sleepMs(10);
   unsigned long iMustBeASmallValue = hw.Millis();
+  hw.Stop();
   TEST_ASSERT_LESS_THAN_INT8(15, iMustBeASmallValue);
 }
 
@@ -72,19 +75,25 @@ void Expect_simulator_to_be_clocked() {
   class TestHw : public hardware::Simulator {
   public:
     int tickCount = 0;
-    void OnTick() override { tickCount++; }
+    void OnTick() override { 
+      tickCount++; 
+    }
+    private:
+      std::mutex _mutex;
   };
+
   unsigned long tickCount;
 
   TestHw hw;
-  uint16_t sleepDuration = 25 * hardware::Simulator::TICK_INTERVAL_MS;
+  const uint8_t ticksToSleep = 10;
+  uint16_t sleepDuration = ticksToSleep * hardware::Simulator::TICK_INTERVAL_MS;
   hw.sleepMs(sleepDuration);
   tickCount = hw.tickCount;
   hw.Stop();
-  TEST_ASSERT_INT_WITHIN(2, 25, tickCount);
+  TEST_ASSERT_INT_WITHIN(5, ticksToSleep, tickCount);
 }
 
-void Expect_simulator_to_wait_10ms_during_waitForEvent() {
+void Expect_simulator_to_wait_30ms_during_waitForEvent() {
   hardware::Simulator hw;
   auto start = std::chrono::high_resolution_clock::now();
   hw.WaitForEvent();
@@ -92,18 +101,21 @@ void Expect_simulator_to_wait_10ms_during_waitForEvent() {
   std::chrono::duration<double, std::milli> elapsed = finish - start;
 
   auto const expectedDelay = 2 * hardware::Simulator::TICK_INTERVAL_MS;
+  hw.Stop();
   TEST_ASSERT_INT_WITHIN(1, expectedDelay, elapsed.count());
 }
 
 void Expect_simulator_to_have_a_primary_action() {
   hardware::Simulator hw;
   hw.TriggerPrimaryAction();
+  hw.Stop();
   TEST_ASSERT_EQUAL(1, hw.PrimaryActionCount());
 }
 
 void Expect_simulator_to_have_a_secondary_action() {
   hardware::Simulator hw;
   hw.TriggerSecondaryAction();
+  hw.Stop();
   TEST_ASSERT_EQUAL(1, hw.SecondaryActionCount());
 }
 
@@ -113,6 +125,6 @@ void Expect_simulator_to_be_able_to_sleep_for_some_ms() {
   hw.sleepMs(250);
   auto finish = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double, std::milli> elapsed = finish - start;
-
+  hw.Stop();
   TEST_ASSERT_INT_WITHIN(1, 250, elapsed.count());
 }


### PR DESCRIPTION
* New implementation for `hardware::Simulator::delayMs()`
* Better stability of tests relying on time